### PR TITLE
Update client.py to deal with no trainServices being returned by Darwin

### DIFF
--- a/custom_components/nationalrailuk/client.py
+++ b/custom_components/nationalrailuk/client.py
@@ -123,12 +123,13 @@ class NationalRailClient:
                         res[each]["filterLocationName"] = batch["filterLocationName"]
                         res[each]["filtercrs"] = batch["filtercrs"]
 
-                    if not res[each][ft["keyName"]]:
-                        res[each][ft["keyName"]] = batch["trainServices"]["service"]
-                    else:
-                        res[each][ft["keyName"]].append(
-                            batch["trainServices"]["service"]
-                        )
+                    if batch["trainServices"]:
+                        if not res[each][ft["keyName"]]:
+                            res[each][ft["keyName"]] = batch["trainServices"]["service"]
+                        else:
+                            res[each][ft["keyName"]].append(
+                                batch["trainServices"]["service"]
+                            )
 
         # with open("output.txt", "w") as convert_file:
         #     convert_file.write(str(res))
@@ -201,7 +202,8 @@ class NationalRailClient:
                 status["trains"] = []
 
                 if not services_list:
-                    return status
+                    res["dests"][each][ft["displayName"]] = {}
+                    continue
 
                 for service in services_list:
                     train = {}


### PR DESCRIPTION
The process was failing where there were no trains scheduled in the next 2 hours - in that instance, there is no "trainServices" object returned by Darwin and so the script failed to return anything to Home Assistant. 

This is amended by checking whether the raw batch results contain the "trainServices" object and then dealing with the situation accordingly when processing the raw data for Home Assistant.

Otherwise, Home Assistance was showing the entity as "unavailable", with no attributes available to use in Home Assistant to show that no trains were available.